### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/tausifanwer/Portfolios/security/code-scanning/1](https://github.com/tausifanwer/Portfolios/security/code-scanning/1)

In general, the fix is to add an explicit `permissions:` block that grants only the minimal access the job needs. For a build-only PR workflow that just checks out code and runs `npm install` and `npm run build`, read access to the repository contents is sufficient, and no write permissions are required.

The single best fix with no behavior change is to add a `permissions:` section scoped to the `build` job in `.github/workflows/pr.yaml`, directly under `runs-on: ubuntu-latest`. Set `contents: read`, which is the minimal permission needed for `actions/checkout` to fetch the code. No other scopes (issues, pull-requests, etc.) are needed since the workflow does not interact with them. Concretely, edit `.github/workflows/pr.yaml` around line 9 to insert:

```yaml
    runs-on: ubuntu-latest
    permissions:
      contents: read
```

No imports or additional methods are required; this is purely a YAML configuration change within the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated workflow permissions to enhance security and consistency in the build process.

---

**Note:** This release contains internal infrastructure updates with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->